### PR TITLE
use rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "node-gyp": "^2.0.2",
     "node-gyp-install": "^1.4.0",
     "npmlog": "^1.2.1",
+    "rc": "^1.0.3",
     "tar-stream": "^1.2.1"
   },
   "devDependencies": {},

--- a/rc.js
+++ b/rc.js
@@ -1,0 +1,14 @@
+var minimist = require('minimist')
+
+module.exports = require('rc')('prebuild', {
+  target: process.version,
+  arch: process.arch,
+  platform: process.platform
+}, minimist(process.argv, {
+  alias: {
+    target: 't',
+    help: 'h',
+    arch: 'a',
+    platform: 'p'
+  }
+}))


### PR DESCRIPTION
Not a lot to gain right now, but you'll be able to use `rc.token` directly for e.g. `ghreleases`, either via cli like `prebuild publish --token 23409sdfljker -t 2.3.0` or stick token into any of the files supported by `rc`.