### PR TITLE
move compile property defaults to rc properties

### DIFF
--- a/rc.js
+++ b/rc.js
@@ -3,7 +3,8 @@ var minimist = require('minimist')
 module.exports = require('rc')('prebuild', {
   target: process.version,
   arch: process.arch,
-  platform: process.platform
+  platform: process.platform,
+  compile: (process.env.npm_config_argv && process.env.npm_config_argv.indexOf('--build-from-source') > -1)
 }, minimist(process.argv, {
   alias: {
     target: 't',
@@ -17,9 +18,5 @@ module.exports = require('rc')('prebuild', {
     'build-from-source': 'compile',
     compile: 'c',
     preinstall: 'i'
-  },
-  default: {
-    // this is hackish - whats the correct way of doing this?
-    compile: !!process.env.prebuild_compile || (process.env.npm_config_argv && process.env.npm_config_argv.indexOf('--build-from-source') > -1)
   }
 }))


### PR DESCRIPTION
Default is unset:

```
$ prebuild
rc { target: 'v2.4.0',
  arch: 'x64',
  platform: 'linux',
  _: [ '/usr/local/bin/iojs', '/usr/local/bin/prebuild' ],
  compile: undefined,
  c: undefined }
```

Using environment variable:

```
$ prebuild_compile=true prebuild
rc { target: 'v2.4.0',
  arch: 'x64',
  platform: 'linux',
  compile: 'true',
  _: [ '/usr/local/bin/iojs', '/usr/local/bin/prebuild' ] }
```

Using `--build-from-source` with npm (from leveldown repo):

```
$ npm install --build-from-source

> leveldown@1.3.1-0 install /home/lms/src/leveldb-repos/leveldown
> prebuild --download

rc { target: 'v2.4.0',
  arch: 'x64',
  platform: 'linux',
  compile: true,
  _: 
   [ '/usr/local/bin/iojs',
     '/home/lms/src/leveldb-repos/leveldown/node_modules/.bin/prebuild' ],
  download: true,
  d: true }
```