### PR TITLE
use mv instead of fs.rename to get around EXDEV errors

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -14,6 +14,7 @@ var github = require('github-from-package')
 var ghreleases = require('ghreleases')
 var os = require('os')
 var proc = require('child_process')
+var mv = require('mv')
 var rc = require('./rc')
 
 if (rc.path) process.chdir(rc.path)
@@ -105,11 +106,17 @@ function downloadPrebuild () {
 
     fs.mkdir(NPM_CACHE, function () {
       pump(req, fs.createWriteStream(tmp), function (err) {
-        if (err) return compile()
+        if (err) {
+          log.warn('pump', err.message)
+          return compile()
+        }
         if (status !== 200) return fs.unlink(tmp, compile)
 
-        fs.rename(tmp, cache, function (err) {
-          if (err) return compile()
+        mv(tmp, cache, function (err) {
+          if (err) {
+            log.warn('rename', err.message)
+            return compile()
+          }
           unpack()
         })
       })

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "ghreleases": "^1.0.2",
     "github-from-package": "0.0.0",
     "minimist": "^1.1.2",
+    "mv": "^2.1.1",
     "node-gyp": "^2.0.2",
     "node-gyp-install": "^1.4.3",
     "npmlog": "^1.2.1",


### PR DESCRIPTION
On debian systems you may get the `EXDEV` error when moving files between devices, e.g.

![exdev](https://cloud.githubusercontent.com/assets/308049/8960481/71d7951c-3610-11e5-837e-538b87f4f1f8.png)
