### PR TITLE
properly report how many files were uploaded

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -59,10 +59,21 @@ async.eachSeries([].concat(rc.target), function (target, next) {
 }, function (err) {
   if (err) return onbuilderror(err)
   if (!rc.upload) return
-  buildLog('Uploading prebuilds to Github releases')
-  upload({pkg: pkg, rc: rc, files: files}, function (err) {
+  buildLog('Uploading ' + files.length + ' prebuilds(s) to Github releases')
+  upload({pkg: pkg, rc: rc, files: files}, function (err, result) {
     if (err) return onbuilderror(err)
-    buildLog('Uploaded ' + files.length + ' new prebuild(s) to Github')
+    buildLog('Found ' + result.old.length + ' prebuild(s) on Github')
+    if (result.old.length) {
+      result.old.forEach(function (build) {
+        buildLog('-> ' + build)
+      })
+    }
+    buildLog('Uploaded ' + result.new.length + ' new prebuild(s) to Github')
+    if (result.new.length) {
+      result.new.forEach(function (build) {
+        buildLog('-> ' + build)
+      })
+    }
   })
 })
 

--- a/test/upload-test.js
+++ b/test/upload-test.js
@@ -48,11 +48,12 @@ test('uploading to GitHub, upload fails if uploadAssets fails', function (t) {
 test('uploading to GitHub, only uploading not uploaded files', function (t) {
   var opts = basicSetup(t, [{name: 'foo.tar.gz' }, {name: 'baz.tar.gz' }])
   var error = new Error('uploadAssets failed miserably, buu huu')
-  opts.gh.uploadAssets = function (auth, user, repo, ref, _files, cb) {
-    t.deepEqual(_files, ['bar.tar.gz'], 'files are filtered correctly')
+  opts.gh.uploadAssets = function (auth, user, repo, ref, filtered, cb) {
     process.nextTick(cb)
   }
-  upload(opts, function (err) {
+  upload(opts, function (err, result) {
+    t.deepEqual(result.new, ['bar.tar.gz'], 'files are filtered correctly')
+    t.deepEqual(result.old, ['foo.tar.gz','baz.tar.gz'], 'files are filtered correctly')
     t.error(err, 'no error')
     t.end()
   })

--- a/upload.js
+++ b/upload.js
@@ -22,13 +22,20 @@ function upload (opts, cb) {
     gh.getByTag(auth, user, repo, tag, function (err, release) {
       if (err) return cb(err)
 
-      files = files.filter(function (file) {
-        return !release.assets.some(function (asset) {
-          return asset.name === path.basename(file)
+      var assets = release.assets.map(function (asset) {
+        return asset.name
+      })
+
+      var filtered = files.filter(function (file) {
+        return !assets.some(function (asset) {
+          return asset === path.basename(file)
         })
       })
 
-      gh.uploadAssets(auth, user, repo, 'tags/' + tag, files, cb)
+      gh.uploadAssets(auth, user, repo, 'tags/' + tag, filtered, function (err) {
+        if (err) return cb(err)
+        cb(null, {new: filtered, old: assets})
+      })
     })
   })
 


### PR DESCRIPTION
I noticed that prebuild doesn't correctly report how many prebuilts that were actually uploaded, e.g. if we are trying to upload 6, it will report that 6 were uploaded even though they were filtered out. Also, while fixing this, why not also print out the prebuilts that were found?

![uploaded-releases](https://cloud.githubusercontent.com/assets/308049/9706317/aea37052-54e1-11e5-8d37-6c7347d26ac9.png)
