### PR TITLE
Make --download search local prebuilds folder first.

### DIFF
--- a/download.js
+++ b/download.js
@@ -9,40 +9,57 @@ var util = require('./util')
 function downloadPrebuild (opts, cb) {
   var downloadUrl = util.getDownloadUrl(opts)
   var cachedPrebuild = util.cachedPrebuild(downloadUrl)
+  var localPrebuild = util.localPrebuild(downloadUrl)
   var tempFile = util.tempFile(cachedPrebuild)
 
   var rc = opts.rc
   var log = opts.log
 
-  fs.exists(cachedPrebuild, function (exists) {
-    if (exists) return unpack()
+  if (opts.nolocal) return download()
 
-    log.http('request', 'GET ' + downloadUrl)
-    var req = get(downloadUrl, function (err, res) {
-      if (err) return onerror(err)
-      log.http(res.statusCode, downloadUrl)
-      if (res.statusCode !== 200) return onerror()
-      fs.mkdir(util.prebuildCache(), function () {
-        pump(res, fs.createWriteStream(tempFile), function (err) {
-          if (err) return onerror(err)
-          fs.rename(tempFile, cachedPrebuild, function (err) {
-            if (err) return cb(err)
-            unpack()
+  log.info('looking for local prebuild @', localPrebuild)
+  fs.exists(localPrebuild, function (exists) {
+    if (exists) {
+      log.info('found. unpacking...')
+      cachedPrebuild = localPrebuild
+      return unpack()
+    }
+
+    log.info('not found. downloading...')
+    download()
+  })
+
+  function download () {
+    fs.exists(cachedPrebuild, function (exists) {
+      if (exists) return unpack()
+
+      log.http('request', 'GET ' + downloadUrl)
+      var req = get(downloadUrl, function (err, res) {
+        if (err) return onerror(err)
+        log.http(res.statusCode, downloadUrl)
+        if (res.statusCode !== 200) return onerror()
+        fs.mkdir(util.prebuildCache(), function () {
+          pump(res, fs.createWriteStream(tempFile), function (err) {
+            if (err) return onerror(err)
+            fs.rename(tempFile, cachedPrebuild, function (err) {
+              if (err) return cb(err)
+              unpack()
+            })
           })
         })
       })
-    })
 
-    req.setTimeout(30 * 1000, function () {
-      req.abort()
-    })
-
-    function onerror (err) {
-      fs.unlink(tempFile, function () {
-        cb(err || new Error('Prebuilt binaries for node version ' + process.version + ' are not available'))
+      req.setTimeout(30 * 1000, function () {
+        req.abort()
       })
-    }
-  })
+
+      function onerror (err) {
+        fs.unlink(tempFile, function () {
+          cb(err || new Error('Prebuilt binaries for node version ' + process.version + ' are not available'))
+        })
+      }
+    })
+  }
 
   function unpack () {
     var binaryName

--- a/test/download-test.js
+++ b/test/download-test.js
@@ -19,6 +19,7 @@ test('downloading from GitHub, not cached', function (t) {
   var requestCount = 0
   var opts = {
     pkg: pkg,
+    nolocal: true,
     rc: {platform: process.platform, arch: process.arch, path: __dirname},
     log: {
       http: function (type, message) {
@@ -106,6 +107,7 @@ test('cached prebuild', function (t) {
 
   var opts = {
     pkg: pkg,
+    nolocal: true,
     rc: {platform: process.platform, arch: process.arch, path: __dirname},
     log: {
       info: function (type, message) {
@@ -155,6 +157,7 @@ test('missing .node file in .tar.gz should fail', function (t) {
 
   var opts = {
     pkg: pkg,
+    nolocal: true,
     rc: {platform: process.platform, arch: process.arch, path: __dirname},
     updateName: function (entry) {
       t.ok(/\.node$/i.test(entry.name), 'should match but we pretend it does not')
@@ -172,6 +175,7 @@ test('non existing host should fail with no dangling temp file', function (t) {
 
   var opts = {
     pkg: pkg,
+    nolocal: true,
     rc: {platform: process.platform, arch: process.arch},
     log: {
       http: function (type, message) {
@@ -208,6 +212,7 @@ test('existing host but invalid url should fail', function (t) {
   var requestCount = 0
   var opts = {
     pkg: pkg,
+    nolocal: true,
     rc: {platform: process.platform, arch: process.arch},
     log: {
       http: function (type, message) {
@@ -251,6 +256,7 @@ test('error during download should fail with no dangling temp file', function (t
   var downloadError = new Error('something went wrong during download')
   var opts = {
     pkg: pkg,
+    nolocal: true,
     rc: {platform: process.platform, arch: process.arch},
     log: {http: function () { }}
   }

--- a/util.js
+++ b/util.js
@@ -71,6 +71,10 @@ function getTarPath (opts, abi) {
   ].join(''))
 }
 
+function localPrebuild (url) {
+  return path.join('prebuilds', path.basename(url))
+}
+
 function readGypFile (version, file, cb) {
   fs.exists(path.join(nodeGypPath(), 'iojs-' + version), function (isIojs) {
     if (isIojs) version = 'iojs-' + version
@@ -114,6 +118,7 @@ function releaseFolder (opts) {
 exports.getDownloadUrl = getDownloadUrl
 exports.urlTemplate = urlTemplate
 exports.cachedPrebuild = cachedPrebuild
+exports.localPrebuild = localPrebuild
 exports.prebuildCache = prebuildCache
 exports.tempFile = tempFile
 exports.getTarPath = getTarPath


### PR DESCRIPTION
This allows me to provide all the prebuilds on my build
server instead of having to rebuild the modules
when not neccessary.