### PR TITLE
Add --electron

### DIFF
--- a/download.js
+++ b/download.js
@@ -10,7 +10,7 @@ var error = require('./error')
 var exec = require('child_process').exec
 
 function transformElectron (opts, cb) {
-  if (!opts.rc.electron) return cb()
+  if (!opts.rc.electron) return process.nextTick(cb)
 
   var log = opts.log
   var local = './node_modules/.bin/electron'


### PR DESCRIPTION
approach taken:
- write a function that transforms the `opts` object in case `opts.rc.electron` is truthy
- ask local electron (from electron-prebuilt) or global electron about its abi
- set `opts.rc.abi` accordingly

questions:
- the script written to `/tmp/electron_abi.js` could also just live as a static file in this module
- is this enough, or should we ensure electron can require this module and if not recompile with the correct settings? (i guess this can just go into the next release)
