### PR TITLE
pass --target to build()

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -54,7 +54,7 @@ var buildLog = log.info.bind(log, 'build')
 var opts = extend(rc, {pkg: pkg, log: log, buildLog: buildLog})
 
 if (opts.compile) {
-  build(opts, process.version, onbuilderror)
+  build(opts, rc.target, onbuilderror)
 } else if (opts.download) {
   download(opts, function (err) {
     if (err) {


### PR DESCRIPTION
so `prebuild download --target=5.1.1` builds for `5.1.1` if it has to build. it still defaults to `process.version`