### PR TITLE
breaking: use .prebuild for prebuild versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,15 @@ prebuild --all
 Alternatively, to build for some specific versions you can do:
 
 ```
-prebuild -t 0.10.41 -t 0.12.9 -t 3.3.1
+prebuild -pb 0.10.41 -pb 0.12.9 -pb 3.3.1
 ```
 
 Optionally, to always build for the above versions you can add the following to `~/.prebuildrc`.
 
 ``` ini
-target[] = 0.10.41
-target[] = 0.12.9
-target[] = 3.3.1
+prebuild[] = 0.10.41
+prebuild[] = 0.12.9
+prebuild[] = 3.3.1
 ```
 
 Note that `~/.prebuildrc` instructs `prebuild` to do this for *all* modules. If this is not what you want you should consider adding a `.prebuildrc` to your project. This way the module determines which version it supports rather than a global setting.
@@ -160,7 +160,8 @@ $ prebuild -h
 prebuild [options]
 
   --path        -p  path        (make a prebuild here)
-  --target      -t  version     (version to prebuild against)
+  --target      -t  version     (version to build or install for)
+  --prebuild    -pb version     (version to prebuild against)
   --all                         (prebuild for all known abi versions)
   --install                     (download when using npm, compile otherwise)
   --download    -d  [url]       (download prebuilds, no url means github)

--- a/bin.js
+++ b/bin.js
@@ -75,7 +75,7 @@ if (opts.compile) {
   })
 } else {
   var files = []
-  async.eachSeries([].concat(opts.target), function (target, next) {
+  async.eachSeries([].concat(opts.prebuild), function (target, next) {
     prebuild(opts, target, function (err, tarGz) {
       if (err) return next(err)
       files.push(tarGz)

--- a/help.txt
+++ b/help.txt
@@ -1,7 +1,8 @@
 prebuild [options]
 
   --path        -p  path        (make a prebuild here)
-  --target      -t  version     (version to prebuild against)
+  --target      -t  version     (version to build or install for)
+  --prebuild    -pb version     (version to prebuild against)
   --all                         (prebuild for all known abi versions)
   --install                     (download when using npm, compile otherwise)
   --download    -d  [url]       (download prebuilds, no url means github)

--- a/rc.js
+++ b/rc.js
@@ -38,6 +38,7 @@ var rc = module.exports = require('rc')('prebuild', {
 }, minimist(process.argv, {
   alias: {
     target: 't',
+    prebuild: 'pb',
     help: 'h',
     arch: 'a',
     path: 'p',
@@ -52,8 +53,8 @@ var rc = module.exports = require('rc')('prebuild', {
 }))
 
 if (rc.all === true) {
-  delete rc.target
-  rc.target = targets
+  delete rc.prebuild
+  rc.prebuild = targets
 }
 
 if (rc['upload-all']) {

--- a/test/rc-test.js
+++ b/test/rc-test.js
@@ -6,8 +6,8 @@ var targets = require('../targets')
 
 test('custom config and aliases', function (t) {
   var args = [
-    '--target vX.Y.Z',
-    '--target vZ.Y.X',
+    '--prebuild vX.Y.Z',
+    '--prebuild vZ.Y.X',
     '--arch ARCH',
     '--platform PLATFORM',
     '--download https://foo.bar',
@@ -23,38 +23,39 @@ test('custom config and aliases', function (t) {
   runRc(t, args.join(' '), {}, function (rc) {
     t.equal(rc.all, false, 'default is not building all targets')
     t.equal(rc.arch, 'ARCH', 'correct arch')
-    t.equal(rc.arch, rc.a)
+    t.equal(rc.arch, rc.a, 'arch alias')
     t.equal(rc.platform, 'PLATFORM', 'correct platform')
     t.equal(rc.download, 'https://foo.bar', 'download is set')
-    t.equal(rc.download, rc.d)
+    t.equal(rc.download, rc.d, 'download alias')
     t.equal(rc.upload, 't00k3n', 'upload token set')
-    t.equal(rc.upload, rc.u)
+    t.equal(rc.upload, rc.u, 'upload alias')
     t.equal(rc.compile, true, 'compile is set')
-    t.equal(rc.compile, rc.c)
+    t.equal(rc.compile, rc.c, 'compile alias')
     t.equal(rc.debug, true, 'debug is set')
     t.equal(rc.force, true, 'force is set')
-    t.equal(rc.force, rc.f)
+    t.equal(rc.force, rc.f, 'force alias')
     t.equal(rc.version, true, 'version is set')
-    t.equal(rc.version, rc.v)
+    t.equal(rc.version, rc.v, 'version alias')
     t.equal(rc.help, true, 'help is set')
-    t.equal(rc.help, rc.h)
+    t.equal(rc.help, rc.h, 'help alias')
     t.equal(rc.path, '../some/other/path', 'correct path')
-    t.equal(rc.path, rc.p)
+    t.equal(rc.path, rc.p, 'path alias')
     t.equal(rc.preinstall, 'somescript.js', 'correct script')
-    t.equal(rc.preinstall, rc.i)
+    t.equal(rc.preinstall, rc.i, 'preinstall alias')
+    t.deepEqual(rc.prebuild, rc.pb, 'prebuild alias')
     t.end()
   })
 })
 
 test('using --all will build for all targets', function (t) {
   var args = [
-    '--target vX.Y.Z',
-    '--target vZ.Y.X',
+    '--prebuild vX.Y.Z',
+    '--prebuild vZ.Y.X',
     '--all'
   ]
   runRc(t, args.join(' '), {}, function (rc) {
     t.equal(rc.all, true, 'should be true')
-    t.deepEqual(rc.target, targets, 'targets picked from targets.js')
+    t.deepEqual(rc.prebuild, targets, 'targets picked from targets.js')
     t.end()
   })
 })


### PR DESCRIPTION
rename the build portion of `--target` to `--prebuild`, so it still looks nice in the prebuildrc.

tests are passing now, i hope though i didn't miss anything.

what do you devs think?