### PR TITLE
delete nvm environment variables

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -37,6 +37,10 @@ if (rc.help) {
 
 log.info('begin', 'Prebuild version', prebuildVersion)
 
+// nvm! do not mess with headers? kkthx!
+delete process.env.NVM_IOJS_ORG_MIRROR
+delete process.env.NVM_NODEJS_ORG_MIRROR
+
 if (rc.install) {
   if (!(typeof pkg._from === 'string')) {
     // From Git directly


### PR DESCRIPTION
`NVM_IOJS_ORG_MIRROR` and `NVM_NODEJS_ORG_MIRROR` environment variables can mess
up headers, delete them to make sure `node-gyp` uses correct url when downloading headers to `~/.node-gyp`

Closes https://github.com/mafintosh/prebuild/issues/84