### PR TITLE
Errors

### DIFF
--- a/abi.js
+++ b/abi.js
@@ -1,5 +1,6 @@
 var gypinstall = require('./gypinstall')
 var util = require('./util')
+var error = require('./error')
 
 function getAbi (opts, version, cb) {
   var log = opts.log
@@ -12,7 +13,7 @@ function getAbi (opts, version, cb) {
         if (err) return cb(err)
         tryReadFiles(function (err, abi) {
           if (!err || err.code !== 'ENOENT') return cb(err, abi)
-          cb(new Error('Failed to locate `node.h` and `node_version.h`.'))
+          cb(error.missingHeaders())
         })
       })
     }
@@ -26,7 +27,7 @@ function getAbi (opts, version, cb) {
       util.readGypFile(version, 'node.h', function (err, b) {
         if (err) return readCb(err)
         var abi = parse(a) || parse(b)
-        if (!abi) return readCb(new Error('Could not detect abi for ' + version))
+        if (!abi) return readCb(error.noAbi(version))
         readCb(null, abi)
       })
     })

--- a/build.js
+++ b/build.js
@@ -1,8 +1,9 @@
 var path = require('path')
 var fs = require('fs')
+var noop = require('noop-logger')
 var releaseFolder = require('./util').releaseFolder
 var gypbuild = require('./gypbuild')
-var noop = require('noop-logger')
+var error = require('./error')
 
 function build (opts, version, cb) {
   var log = opts.log || noop
@@ -23,7 +24,7 @@ function build (opts, version, cb) {
           return cb(null, path.join(release, files[i]), files[i])
         }
       }
-      cb(new Error('Could not find build in ' + release))
+      cb(error.noBuild(release))
     })
   }
 }

--- a/download.js
+++ b/download.js
@@ -81,7 +81,7 @@ function downloadPrebuild (opts, cb) {
     log.info('unpacking @', cachedPrebuild)
     pump(fs.createReadStream(cachedPrebuild), zlib.createGunzip(), tfs.extract(opts.path, {readable: true, writable: true}).on('entry', updateName), function (err) {
       if (err) return cb(err)
-      if (!binaryName) return cb(new Error('Missing .node file in archive'))
+      if (!binaryName) return cb(error.invalidArchive())
 
       var resolved
       try {

--- a/download.js
+++ b/download.js
@@ -3,9 +3,10 @@ var fs = require('fs')
 var get = require('simple-get')
 var pump = require('pump')
 var tfs = require('tar-fs')
+var noop = require('noop-logger')
 var zlib = require('zlib')
 var util = require('./util')
-var noop = require('noop-logger')
+var error = require('./error')
 
 function downloadPrebuild (opts, cb) {
   var downloadUrl = util.getDownloadUrl(opts)
@@ -64,7 +65,7 @@ function downloadPrebuild (opts, cb) {
 
       function onerror (err) {
         fs.unlink(tempFile, function () {
-          cb(err || new Error('Prebuilt binaries for node version ' + opts.target + ' are not available'))
+          cb(err || error.noPrebuilts(opts))
         })
       }
     })

--- a/error.js
+++ b/error.js
@@ -6,3 +6,27 @@ exports.noPrebuilts = function (opts) {
     'platform=' + opts.platform + ')'
   ].join(' '))
 }
+
+exports.missingHeaders = function () {
+  return new Error('Failed to locate `node.h` and `node_version.h`.')
+}
+
+exports.noAbi = function (v) {
+  return new Error('Could not detect abi for version ' + v)
+}
+
+exports.noBuild = function (folder) {
+  return new Error('Could not find build in ' + folder)
+}
+
+exports.invalidArchive = function () {
+  return new Error('Missing .node file in archive')
+}
+
+exports.noRepository = function () {
+  return new Error('package.json is missing a repository field')
+}
+
+exports.spawnFailed = function (cmd, args, code) {
+  return new Error(cmd + ' ' + args.join(' ') + ' failed with exit code ' + code)
+}

--- a/error.js
+++ b/error.js
@@ -1,0 +1,8 @@
+exports.noPrebuilts = function (opts) {
+  return new Error([
+    'No prebuilt binaries found',
+    '(target=' + opts.target,
+    'arch=' + opts.arch,
+    'platform=' + opts.platform + ')'
+  ].join(' '))
+}

--- a/test/abi-test.js
+++ b/test/abi-test.js
@@ -1,6 +1,7 @@
 var test = require('tape')
 var util = require('../util')
 var getAbi = require('../abi')
+var error = require('../error')
 
 test('src/node_version.h takes precedence over src/node.h', function (t) {
   var readCount = 0
@@ -50,7 +51,7 @@ test('getAbi calls back with error if no abi could be found', function (t) {
     process.nextTick(cb.bind(null, null, 'no proper define here!'))
   }
   getAbi({}, v, function (err, abi) {
-    t.equal(err.message, 'Could not detect abi for X.Y.Z', 'correct error')
+    t.same(err, error.noAbi(v), 'correct error')
     util.readGypFile = _readGypFile
     t.end()
   })

--- a/test/download-test.js
+++ b/test/download-test.js
@@ -2,10 +2,11 @@ var test = require('tape')
 var fs = require('fs')
 var rm = require('rimraf')
 var path = require('path')
-var download = require('../download')
-var util = require('../util')
 var http = require('http')
 var https = require('https')
+var download = require('../download')
+var util = require('../util')
+var error = require('../error')
 
 var build = path.join(__dirname, 'build')
 var unpacked = path.join(build, 'Release/leveldown.node')
@@ -211,7 +212,7 @@ test('existing host but invalid url should fail', function (t) {
     res.end()
   }).listen(8888, function () {
     download(opts, function (err) {
-      t.equal(err.message, 'Prebuilt binaries for node version ' + process.version + ' are not available', 'correct error')
+      t.same(err, error.noPrebuilts(opts))
       t.equal(fs.existsSync(cachedPrebuild), false, 'nothing cached')
       t.end()
       server.unref()

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -4,6 +4,7 @@ var home = require('os-homedir')
 var cp = require('child_process')
 var EventEmitter = require('events').EventEmitter
 var util = require('../util')
+var error = require('../error')
 
 var spawn = util.spawn
 
@@ -238,7 +239,7 @@ test('spawn(): callback fires with no error on exit code 0', function (t) {
 test('spawn(): callback fires with error on non 0 exit code', function (t) {
   cp.spawn = function () { return new EventEmitter() }
   spawn('foo', ['arg1'], function (err) {
-    t.equal(err.message, 'foo arg1 failed with exit code 314', 'correct error')
+    t.same(err, error.spawnFailed('foo', ['arg1'], 314))
     t.end()
   }).emit('exit', 314)
 })

--- a/upload.js
+++ b/upload.js
@@ -1,6 +1,7 @@
 var path = require('path')
 var github = require('github-from-package')
 var ghreleases = require('ghreleases')
+var error = require('./error')
 
 function upload (opts, cb) {
   var pkg = opts.pkg
@@ -10,7 +11,7 @@ function upload (opts, cb) {
   var url = github(pkg)
   if (!url) {
     return process.nextTick(function () {
-      cb(new Error('package.json is missing a repository field'))
+      cb(error.noRepository())
     })
   }
 

--- a/util.js
+++ b/util.js
@@ -4,6 +4,7 @@ var github = require('github-from-package')
 var home = require('os-homedir')
 var cp = require('child_process')
 var expandTemplate = require('expand-template')()
+var error = require('./error')
 
 function getDownloadUrl (opts) {
   var pkgName = opts.pkg.name.replace(/^@\w+\//, '')
@@ -104,7 +105,7 @@ function spawn (cmd, args, cb) {
   }
   return cp.spawn(cmd, args, {stdio: 'inherit'}).on('exit', function (code) {
     if (code === 0) return cb()
-    cb(new Error(cmd + ' ' + args.join(' ') + ' failed with exit code ' + code))
+    cb(error.spawnFailed(cmd, args, code))
   })
 }
 


### PR DESCRIPTION
Main reason for this was to get more detailed error information when no prebuilts can be found (see https://github.com/Level/leveldown/issues/254). That error just tells us we couldn't find any prebuilts for a certain node version. This way we don't need to ask "hey what platform, arch are you using?", we already have that information in the error.

Also moved out errors into `error.js`, which also makes it easier to test.