### PR TITLE
Added --backend=node-ninja option

### DIFF
--- a/abi.js
+++ b/abi.js
@@ -22,9 +22,9 @@ function getAbi (opts, version, cb) {
   })
 
   function tryReadFiles (readCb) {
-    util.readGypFile(version, 'node_version.h', function (err, a) {
+    util.readGypFile(opts, version, 'node_version.h', function (err, a) {
       if (err) return readCb(err)
-      util.readGypFile(version, 'node.h', function (err, b) {
+      util.readGypFile(opts, version, 'node.h', function (err, b) {
         if (err) return readCb(err)
         var abi = parse(a) || parse(b)
         if (!abi) return readCb(error.noAbi(version))

--- a/gyp.js
+++ b/gyp.js
@@ -1,10 +1,11 @@
 var nodeGyp = require('node-gyp')()
+var nodeNinja = require('node-ninja')()
 
 function runGyp (opts, cb) {
-  var gyp = opts.gyp || nodeGyp
+  var gyp = opts.backend === "node-gyp"? nodeGyp: nodeNinja
   var log = opts.log
 
-  log.verbose('execute node-gyp with `' + opts.args.join(' ') + '`')
+  log.verbose('execute ' + opts.backend + ' with `' + opts.args.join(' ') + '`')
   gyp.parseArgv(opts.args)
 
   function runStep () {

--- a/gypbuild.js
+++ b/gypbuild.js
@@ -18,6 +18,7 @@ function runGyp (opts, version, cb) {
     gyp({
       gyp: opts.gyp,
       log: opts.log,
+      backend: opts.backend,
       args: args,
       filter: function (command) {
         if (command.name === 'configure') {

--- a/help.txt
+++ b/help.txt
@@ -12,6 +12,7 @@ prebuild [options]
   --compile     -c              (compile your project using node-gyp)
   --no-compile                  (skip compile fallback when downloading)
   --abi                         (use provided abi rather than system abi)
+  --backend                     (specify build backend, default is 'node-gyp')
   --strip                       (strip debug information)
   --debug                       (set Debug or Release configuration)
   --verbose                     (log verbosely)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "minimist": "^1.1.2",
     "mkdirp": "^0.5.1",
     "node-gyp": "^3.0.3",
+    "node-ninja": "^0.3.0",
     "noop-logger": "^0.1.0",
     "npmlog": "^2.0.0",
     "os-homedir": "^1.0.1",

--- a/prebuild.js
+++ b/prebuild.js
@@ -12,7 +12,7 @@ function prebuild (opts, target, callback) {
   var buildLog = opts.buildLog || function () {}
 
   if (target[0] !== 'v') target = 'v' + target
-  buildLog('Preparing to prebuild ' + pkg.name + '@' + pkg.version + ' for ' + target + ' on ' + opts.platform + '-' + opts.arch)
+  buildLog('Preparing to prebuild ' + pkg.name + '@' + pkg.version + ' for ' + target + ' on ' + opts.platform + '-' + opts.arch + ' using ' + opts.backend)
   getAbi(opts, target, function (err, abi) {
     if (err) return log.error('build', err.message)
     var tarPath = getTarPath(opts, abi)

--- a/rc.js
+++ b/rc.js
@@ -33,6 +33,7 @@ var rc = module.exports = require('rc')('prebuild', {
   force: false,
   debug: false,
   path: '.',
+  backend: 'node-gyp',
   proxy: process.env['HTTP_PROXY'],
   'https-proxy': process.env['HTTPS_PROXY']
 }, minimist(process.argv, {

--- a/util.js
+++ b/util.js
@@ -79,14 +79,15 @@ function localPrebuild (url) {
   return path.join('prebuilds', path.basename(url))
 }
 
-function readGypFile (version, file, cb) {
-  fs.exists(path.join(nodeGypPath(), 'iojs-' + version), function (isIojs) {
+function readGypFile (opts, version, file, cb) {
+  var directory = '.' + opts.backend
+  fs.exists(path.join(nodeGypPath(directory), 'iojs-' + version), function (isIojs) {
     if (isIojs) version = 'iojs-' + version
-    fs.exists(nodeGypPath(version, 'include/node'), function (exists) {
+    fs.exists(nodeGypPath(directory, version, 'include/node'), function (exists) {
       if (exists) {
-        fs.readFile(nodeGypPath(version, 'include/node', file), 'utf-8', cb)
+        fs.readFile(nodeGypPath(directory, version, 'include/node', file), 'utf-8', cb)
       } else {
-        fs.readFile(nodeGypPath(version, 'src', file), 'utf-8', cb)
+        fs.readFile(nodeGypPath(directory, version, 'src', file), 'utf-8', cb)
       }
     })
   })
@@ -94,7 +95,7 @@ function readGypFile (version, file, cb) {
 
 function nodeGypPath () {
   var args = [].slice.call(arguments)
-  return path.join(home(), '.node-gyp', args.join('/'))
+  return path.join(home(), args.join('/'))
 }
 
 function spawn (cmd, args, cb) {


### PR DESCRIPTION
This lets us use node-ninja as backend instead of node-gyp. There
are two main reasons to want this:

- node-ninja fixes a bug in node-gyp/gyp where makefiles end up
  in arbitrary places on the filesystem (while the bug may get
  fixed in gyp, this is a blocking issue.)

- node-ninja offers a --builddir option for compiler output; we
  can use this to make incremental builds by puttting each ABI
  version in its own build directory.

More generally this removes the long-term dependency on gyp, as
we can add arbitrary backends. Node-ninja will aim to support the
newer Ninja make system instead of gyp/make.

Caveat: I did not make the backends optional dependencies, so you
both node-gyp and node-ninja are marked as dependencies.