### PR TITLE
Fixed inconsistencies in the help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ prebuild [options]
 
   --path        -p  path        (make a prebuild here)
   --target      -t  version     (version to build or install for)
-  --prebuild    -b version      (version to prebuild against)
+  --prebuild    -b  version     (version to prebuild against)
   --all                         (prebuild for all known abi versions)
   --install                     (download when using npm, compile otherwise)
   --download    -d  [url]       (download prebuilds, no url means github)

--- a/help.txt
+++ b/help.txt
@@ -2,7 +2,7 @@ prebuild [options]
 
   --path        -p  path        (make a prebuild here)
   --target      -t  version     (version to build or install for)
-  --prebuild    -pb version     (version to prebuild against)
+  --prebuild    -b  version     (version to prebuild against)
   --all                         (prebuild for all known abi versions)
   --install                     (download when using npm, compile otherwise)
   --download    -d  [url]       (download prebuilds, no url means github)


### PR DESCRIPTION
We still had the -pb option in help.txt, and --backend wasn't in
README.md. They're consistent now.