### PR TITLE
Problem: Failed to locate `node.h` and `node_version.h`

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ This command would:
 * Create a release on GitHub, if needed
 * Upload all binaries to that release, if not already uploaded
 
+Before you commit your changes and send us a pull request, do run `npm test`.
+
 ## License
 
 MIT

--- a/abi.js
+++ b/abi.js
@@ -9,7 +9,8 @@ function getAbi (opts, version, cb) {
 
   tryReadFiles(function (err, abi) {
     if (err && err.code === 'ENOENT') {
-      return install({log: log, force: true}, version, function (err) {
+      return install({ log: log, force: true, backend: opts.backend},
+                     version, function (err) {
         if (err) return cb(err)
         tryReadFiles(function (err, abi) {
           if (!err || err.code !== 'ENOENT') return cb(err, abi)

--- a/abi.js
+++ b/abi.js
@@ -9,15 +9,15 @@ function getAbi (opts, version, cb) {
 
   tryReadFiles(function (err, abi) {
     if (err && err.code === 'ENOENT') {
-    return install({
+      return install({
         log: log,
         force: true,
         backend: opts.backend
       }, version, function (err) {
         if (err) return cb(err)
         tryReadFiles(function (err, abi) {
-        if (!err || err.code !== 'ENOENT') return cb(err, abi)
-        cb(error.missingHeaders())
+          if (!err || err.code !== 'ENOENT') return cb(err, abi)
+          cb(error.missingHeaders())
         })
       })
     }

--- a/abi.js
+++ b/abi.js
@@ -9,16 +9,18 @@ function getAbi (opts, version, cb) {
 
   tryReadFiles(function (err, abi) {
     if (err && err.code === 'ENOENT') {
-      return install({ log: log, force: true, backend: opts.backend},
-                     version, function (err) {
+    return install({
+        log: log,
+        force: true,
+        backend: opts.backend
+      }, version, function (err) {
         if (err) return cb(err)
         tryReadFiles(function (err, abi) {
-          if (!err || err.code !== 'ENOENT') return cb(err, abi)
-          cb(error.missingHeaders())
+        if (!err || err.code !== 'ENOENT') return cb(err, abi)
+        cb(error.missingHeaders())
         })
       })
     }
-
     cb(err, abi)
   })
 

--- a/gypbuild.js
+++ b/gypbuild.js
@@ -13,7 +13,7 @@ function runGyp (opts, version, cb) {
 
   function run () {
     var args = ['node', 'index.js']
-    if (opts.backend === "node-ninja") {
+    if (opts.backend === 'node-ninja') {
       args.push('configure')
       args.push('build')
       args.push('--builddir=build/' + version)

--- a/gypbuild.js
+++ b/gypbuild.js
@@ -12,7 +12,16 @@ function runGyp (opts, version, cb) {
   })
 
   function run () {
-    var args = ['node', 'index.js', 'rebuild', '--target=' + version, '--target_arch=' + opts.arch]
+    var args = ['node', 'index.js']
+    if (opts.backend === "node-ninja") {
+      args.push('configure')
+      args.push('build')
+      args.push('--builddir=build/' + version)
+    } else {
+      args.push('rebuild')
+    }
+    args.push('--target=' + version)
+    args.push('--target_arch=' + opts.arch)
     if (opts.debug) args.push('--debug')
 
     gyp({
@@ -20,6 +29,7 @@ function runGyp (opts, version, cb) {
       backend: opts.backend,
       log: opts.log,
       args: args,
+      version: version,
       filter: function (command) {
         if (command.name === 'configure') {
           return configurePreGyp(command, opts)

--- a/gypinstall.js
+++ b/gypinstall.js
@@ -4,6 +4,7 @@ var gyp = require('./gyp')
 function runGypInstall (opts, version, cb) {
   gyp({
     log: opts.log,
+    backend: opts.backend,
     args: ['node', 'index.js', 'install', version]
   }, cb)
 }


### PR DESCRIPTION
Hits when installing new ABI versions. Cause was gypinstall.js not
passing the backend down to gyp, so headers were installed into
$HOME/.node-gyp when using the --backend=node-ninja.

Solution: gypinstall.js passes opts.backend down when calling backend.