### PR TITLE
Accept an environment variable for the token

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ For more options run `prebuild --help`. The prebuilds created are compatible wit
 $ prebuild --all -u <github-token>
 ```
 
-If you don't want to use the token on cli you can also stick that in e.g. `~/.prebuildrc`:
+If you don't want to use the token on cli you can also either use an environment variable (useful in Docker build environments):
+
+```
+export GITHUB_TOKEN=<github-token>
+```
+
+or stick it in e.g. `~/.prebuildrc`:
 
 ```json
 {

--- a/upload.js
+++ b/upload.js
@@ -17,7 +17,7 @@ function upload (opts, cb) {
 
   var user = url.split('/')[3]
   var repo = url.split('/')[4]
-  var auth = {user: 'x-oauth', token: opts.upload}
+  var auth = {user: 'x-oauth', token: opts.upload || process.env.GITHUB_TOKEN}
   var tag = 'v' + pkg.version
 
   gh.create(auth, user, repo, {tag_name: tag}, function () {


### PR DESCRIPTION
This allows us to do the uploads in a Docker container by doing a build and run with `-e GITHUB_TOKEN=TOKEN`