### PR TITLE
Add option for custom libc

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Add `prebuild --install` to your `package.json` so the binaries will be installe
 If you are hosting your binaries elsewhere you can provide a host to the `--install` flag. The host string can also be a template for constructing more intrinsic urls. Install from `example.com` with a custom format for the binary name:
 
 ```
-$ prebuild --install https://example.com/{name}-{version}-{abi}-{platform}-{arch}.tar.gz
+$ prebuild --install https://example.com/{name}-{version}-{abi}-{platform}{libc}-{arch}.tar.gz
 ```
 
 `--install` will download binaries when installing from npm and compile in other cases. If you want `prebuild` to always download binaries you can use `--download` instead of `--install`. Either way, if downloading fails for any reason, it will fallback to compiling the code.
@@ -105,6 +105,7 @@ The following placeholders can be used:
 * `{abi}` or `{node_abi}`: ABI version of node/iojs taken from current `--target` or `process.version` if not specified, see `ABI` section below for more information
 * `{platform}`: platform taken from `--platform` or `process.platform` if not specified
 * `{arch}`: architecture taken from `--arch` or `process.arch` if not specified
+* `{libc}`: libc setting for alternative libc taken from `--libc` or blank if not specified
 * `{configuration}`: `'Debug'` if `--debug` is specified, otherwise `'Release'`
 * `{module_name}`: taken from `binary.module_name` property from `package.json`
 
@@ -143,6 +144,7 @@ prebuild [options]
   --compile     -c              (compile your project using node-gyp)
   --no-compile                  (skip compile fallback when downloading)
   --abi                         (use provided abi rather than system abi)
+  --libc                        (use provided libc rather than system default)
   --backend                     (specify build backend, default is 'node-gyp')
   --strip                       (strip debug information)
   --debug                       (set Debug or Release configuration)
@@ -166,6 +168,7 @@ Options:
 - `.updateName` Function to update the binary name (optional)
 - `.path` Location of the module (default: `"."`)
 - `.abi` Node ABI version (default: `process.versions.modules`)
+- `.libc` OS libc (default: blank)
 - `.platform` OS platform (default: `process.platform`)
 - `.download` Precomputed url to download the binary from (optional)
 - `.all` (default: `false`)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The following placeholders can be used:
 * `{abi}` or `{node_abi}`: ABI version of node/iojs taken from current `--target` or `process.version` if not specified, see `ABI` section below for more information
 * `{platform}`: platform taken from `--platform` or `process.platform` if not specified
 * `{arch}`: architecture taken from `--arch` or `process.arch` if not specified
-* `{libc}`: libc setting for alternative libc taken from `--libc` or blank if not specified
+* `{libc}`: libc setting for alternative libc taken from `--libc` or LIBC env var or blank if not specified
 * `{configuration}`: `'Debug'` if `--debug` is specified, otherwise `'Release'`
 * `{module_name}`: taken from `binary.module_name` property from `package.json`
 

--- a/help.txt
+++ b/help.txt
@@ -12,6 +12,7 @@ prebuild [options]
   --compile     -c              (compile your project using node-gyp)
   --no-compile                  (skip compile fallback when downloading)
   --abi                         (use provided abi rather than system abi)
+  --libc                        (use provided libc rather than system default)
   --backend                     (specify build backend, default is 'node-gyp')
   --strip                       (strip debug information)
   --debug                       (set Debug or Release configuration)

--- a/prebuild.js
+++ b/prebuild.js
@@ -12,7 +12,9 @@ function prebuild (opts, target, callback) {
   var buildLog = opts.buildLog || function () {}
 
   if (target[0] !== 'v') target = 'v' + target
-  buildLog('Preparing to prebuild ' + pkg.name + '@' + pkg.version + ' for ' + target + ' on ' + opts.platform + '-' + opts.arch + ' using ' + opts.backend)
+  var buildLogMessage = 'Preparing to prebuild ' + pkg.name + '@' + pkg.version + ' for ' + target + ' on ' + opts.platform + '-' + opts.arch + ' using ' + opts.backend
+  if (opts.libc && opts.libc.length > 0) buildLogMessage += 'using libc ' + opts.libc
+  buildLog(buildLogMessage)
   getAbi(opts, target, function (err, abi) {
     if (err) return log.error('build', err.message)
     var tarPath = getTarPath(opts, abi)

--- a/rc.js
+++ b/rc.js
@@ -28,7 +28,7 @@ for (var j = 0; j < npmconfigs.length; ++j) {
 var rc = module.exports = require('rc')('prebuild', {
   target: process.version,
   arch: process.arch,
-  libc: '',
+  libc: process.env.LIBC,
   platform: process.platform,
   all: false,
   force: false,

--- a/rc.js
+++ b/rc.js
@@ -28,6 +28,7 @@ for (var j = 0; j < npmconfigs.length; ++j) {
 var rc = module.exports = require('rc')('prebuild', {
   target: process.version,
   arch: process.arch,
+  libc: '',
   platform: process.platform,
   all: false,
   force: false,

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -46,7 +46,7 @@ test('urlTemplate() returns different templates based on pkg and rc', function (
     pkg: {binary: {host: 'http://foo.com'}}
   }
   var t2 = util.urlTemplate(o2)
-  t.equal(t2, 'http://foo.com/{name}-v{version}-node-v{abi}-{platform}-{arch}.tar.gz', 'template based on pkg.binary properties')
+  t.equal(t2, 'http://foo.com/{name}-v{version}-node-v{abi}-{platform}{libc}-{arch}.tar.gz', 'template based on pkg.binary properties')
   var o3 = {
     pkg: {binary: {host: 'http://foo.com'}},
     download: true
@@ -63,7 +63,7 @@ test('urlTemplate() returns different templates based on pkg and rc', function (
     pkg: {binary: {host: 'http://foo.com', remote_path: 'w00t'}}
   }
   var t5 = util.urlTemplate(o5)
-  t.equal(t5, 'http://foo.com/w00t/{name}-v{version}-node-v{abi}-{platform}-{arch}.tar.gz', 'pkg.binary.remote_path is added after host, default format')
+  t.equal(t5, 'http://foo.com/w00t/{name}-v{version}-node-v{abi}-{platform}{libc}-{arch}.tar.gz', 'pkg.binary.remote_path is added after host, default format')
   var o6 = {
     pkg: {
       binary: {
@@ -77,7 +77,7 @@ test('urlTemplate() returns different templates based on pkg and rc', function (
   t.equal(t6, 'http://foo.com/w00t/{name}-{major}.{minor}-node-v{abi}-{platform}-{arch}.tar.gz', 'pkg.binary.package_name is added after host and remote_path, custom format')
   var o7 = {pkg: require('../package.json'), download: true}
   var t7 = util.urlTemplate(o7)
-  t.equal(t7, 'https://github.com/mafintosh/prebuild/releases/download/v{version}/{name}-v{version}-node-v{abi}-{platform}-{arch}.tar.gz', '--download with no arguments, no pkg.binary, default format')
+  t.equal(t7, 'https://github.com/mafintosh/prebuild/releases/download/v{version}/{name}-v{version}-node-v{abi}-{platform}{libc}-{arch}.tar.gz', '--download with no arguments, no pkg.binary, default format')
   t.end()
 })
 

--- a/util.js
+++ b/util.js
@@ -21,6 +21,7 @@ function getDownloadUrl (opts) {
     node_abi: process.versions.modules,
     platform: opts.platform,
     arch: opts.arch,
+    libc: opts.libc || '',
     configuration: (opts.debug ? 'Debug' : 'Release'),
     module_name: opts.pkg.binary && opts.pkg.binary.module_name
   })
@@ -31,7 +32,7 @@ function urlTemplate (opts) {
     return opts.download
   }
 
-  var packageName = '{name}-v{version}-node-v{abi}-{platform}-{arch}.tar.gz'
+  var packageName = '{name}-v{version}-node-v{abi}-{platform}{libc}-{arch}.tar.gz'
   if (opts.pkg.binary) {
     return [
       opts.pkg.binary.host,

--- a/util.js
+++ b/util.js
@@ -72,7 +72,7 @@ function getTarPath (opts, abi) {
     '-node-v', abi,
     '-', opts.platform,
     '-', opts.arch,
-    opts.libc || '',
+    opts.libc,
     '.tar.gz'
   ].join(''))
 }

--- a/util.js
+++ b/util.js
@@ -72,6 +72,7 @@ function getTarPath (opts, abi) {
     '-node-v', abi,
     '-', opts.platform,
     '-', opts.arch,
+    opts.libc || '',
     '.tar.gz'
   ].join(''))
 }

--- a/util.js
+++ b/util.js
@@ -71,8 +71,8 @@ function getTarPath (opts, abi) {
     '-v', opts.pkg.version,
     '-node-v', abi,
     '-', opts.platform,
-    '-', opts.arch,
     opts.libc,
+    '-', opts.arch,
     '.tar.gz'
   ].join(''))
 }

--- a/util.js
+++ b/util.js
@@ -21,7 +21,7 @@ function getDownloadUrl (opts) {
     node_abi: process.versions.modules,
     platform: opts.platform,
     arch: opts.arch,
-    libc: opts.libc || '',
+    libc: opts.libc || process.env.LIBC || '',
     configuration: (opts.debug ? 'Debug' : 'Release'),
     module_name: opts.pkg.binary && opts.pkg.binary.module_name
   })


### PR DESCRIPTION
This is meant to fix https://github.com/mafintosh/prebuild/issues/108

It adds an option for libc argument and LIBC environment variable for use in systems like Alpine linux that use a custom libc.

I was unable to run the test suite on my Mac as it seems it is not currently working for node 6.0 but I am happy to add some tests as advised. 

I have tested it using a scoped package which can be downloaded from NPM as @corbinu/prebuild. 

I also released a version using it and the generated artifacts and travis script can be seen here: https://github.com/corbinu/couchnode