### PR TITLE
replace simple-get to send requests through configured proxy

### DIFF
--- a/download.js
+++ b/download.js
@@ -41,9 +41,8 @@ function downloadPrebuild (opts, cb) {
         }
 
         fs.mkdir(util.prebuildCache(), function () {
-
-          var stream = fs.createWriteStream(tempFile);
-          stream.on('open', function() {
+          var stream = fs.createWriteStream(tempFile)
+          stream.on('open', function () {
             request({
               url: downloadUrl,
               encoding: null,
@@ -64,13 +63,10 @@ function downloadPrebuild (opts, cb) {
               })
             }).pipe(stream)
           })
-          
-          stream.on('error', function(err) {
+          stream.on('error', function (err) {
             return onerror(err)
           })
-
         })
-        
       })
 
       function onerror (err) {

--- a/download.js
+++ b/download.js
@@ -47,9 +47,8 @@ function downloadPrebuild (opts, cb) {
               url: downloadUrl,
               encoding: null,
               timeout: 3 * 1000
-            }).on('error', function (err) {
-              return onerror(err)
-            }).on('response', function (res) {
+            }).on('error', onerror)
+            .on('response', function (res) {
               log.http(res.statusCode, downloadUrl)
               if (res.statusCode !== 200) return onerror()
               log.info('downloading to @', tempFile)
@@ -63,9 +62,7 @@ function downloadPrebuild (opts, cb) {
               })
             }).pipe(stream)
           })
-          stream.on('error', function (err) {
-            return onerror(err)
-          })
+          stream.on('error', onerror)
         })
       })
 

--- a/download.js
+++ b/download.js
@@ -1,6 +1,6 @@
 var path = require('path')
 var fs = require('fs')
-var get = require('simple-get')
+var request = require('request')
 var pump = require('pump')
 var tfs = require('tar-fs')
 var noop = require('noop-logger')
@@ -40,27 +40,37 @@ function downloadPrebuild (opts, cb) {
           return unpack()
         }
 
-        log.http('request', 'GET ' + downloadUrl)
-        var req = get(downloadUrl, function (err, res) {
-          if (err) return onerror(err)
-          log.http(res.statusCode, downloadUrl)
-          if (res.statusCode !== 200) return onerror()
-          fs.mkdir(util.prebuildCache(), function () {
-            log.info('downloading to @', tempFile)
-            pump(res, fs.createWriteStream(tempFile), function (err) {
-              if (err) return onerror(err)
-              fs.rename(tempFile, cachedPrebuild, function (err) {
-                if (err) return cb(err)
-                log.info('renaming to @', cachedPrebuild)
-                unpack()
-              })
-            })
-          })
-        })
+        fs.mkdir(util.prebuildCache(), function () {
 
-        req.setTimeout(30 * 1000, function () {
-          req.abort()
+          var stream = fs.createWriteStream(tempFile);
+          stream.on('open', function() {
+            request({
+              url: downloadUrl,
+              encoding: null,
+              timeout: 3 * 1000
+            }).on('error', function (err) {
+              return onerror(err)
+            }).on('response', function (res) {
+              log.http(res.statusCode, downloadUrl)
+              if (res.statusCode !== 200) return onerror()
+              log.info('downloading to @', tempFile)
+
+              stream.on('close', function () {
+                fs.rename(tempFile, cachedPrebuild, function (err) {
+                  if (err) return cb(err)
+                  log.info('renaming to @', cachedPrebuild)
+                  unpack()
+                })
+              })
+            }).pipe(stream)
+          })
+          
+          stream.on('error', function(err) {
+            return onerror(err)
+          })
+
         })
+        
       })
 
       function onerror (err) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "expand-template": "^1.0.0",
     "ghreleases": "^1.0.2",
     "github-from-package": "0.0.0",
-    "got": "^5.6.0",
     "minimist": "^1.1.2",
     "mkdirp": "^0.5.1",
     "node-gyp": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "expand-template": "^1.0.0",
     "ghreleases": "^1.0.2",
     "github-from-package": "0.0.0",
+    "got": "^5.6.0",
     "minimist": "^1.1.2",
     "mkdirp": "^0.5.1",
     "node-gyp": "^3.0.3",
@@ -32,7 +33,7 @@
     "os-homedir": "^1.0.1",
     "pump": "^1.0.0",
     "rc": "^1.0.3",
-    "simple-get": "^1.4.2",
+    "request": "^2.72.0",
     "tar-fs": "^1.7.0",
     "tar-stream": "^1.2.1",
     "xtend": "^4.0.1"

--- a/test/download-test.js
+++ b/test/download-test.js
@@ -78,7 +78,7 @@ test('downloading from GitHub, not cached', function (t) {
   var _request = https.request
   https.request = function (opts) {
     https.request = _request
-    t.equal('https://' + opts.hostname + opts.path, downloadUrl, 'correct url')
+    t.equal('https://' + opts.uri.hostname + opts.uri.path, downloadUrl, 'correct url')
     return _request.apply(https, arguments)
   }
 
@@ -169,7 +169,7 @@ test('missing .node file in .tar.gz should fail', function (t) {
 })
 
 test('non existing host should fail with no dangling temp file', function (t) {
-  t.plan(3)
+  t.plan(4)
 
   var opts = getOpts()
   opts.pkg.binary = {
@@ -178,19 +178,14 @@ test('non existing host should fail with no dangling temp file', function (t) {
 
   var downloadUrl = util.getDownloadUrl(opts)
   var cachedPrebuild = util.cachedPrebuild(downloadUrl)
-
-  var _createWriteStream = fs.createWriteStream.bind(fs)
-  fs.createWriteStream = function (path) {
-    t.ok(false, 'no temporary file should be written')
-    return _createWriteStream(path)
-  }
+  var tempFile = util.tempFile(cachedPrebuild)
 
   t.equal(fs.existsSync(cachedPrebuild), false, 'nothing cached')
 
   download(opts, function (err) {
     t.ok(err, 'should error')
+    t.equal(fs.existsSync(tempFile), false, 'no temporary file should be written')
     t.equal(fs.existsSync(cachedPrebuild), false, 'nothing cached')
-    fs.createWriteStream = _createWriteStream
   })
 })
 
@@ -213,7 +208,7 @@ test('existing host but invalid url should fail', function (t) {
     res.end()
   }).listen(8888, function () {
     download(opts, function (err) {
-      t.same(err, error.noPrebuilts(opts))
+      t.same(err, error.noPrebuilts(opts), 'got a cool error')
       t.equal(fs.existsSync(cachedPrebuild), false, 'nothing cached')
       t.end()
       server.unref()
@@ -222,7 +217,7 @@ test('existing host but invalid url should fail', function (t) {
 })
 
 test('error during download should fail with no dangling temp file', function (t) {
-  t.plan(7)
+  t.plan(6)
 
   var downloadError = new Error('something went wrong during download')
 
@@ -247,14 +242,7 @@ test('error during download should fail with no dangling temp file', function (t
   var _request = http.request
   http.request = function (opts) {
     http.request = _request
-    t.equal('http://' + opts.hostname + ':' + opts.port + opts.path, downloadUrl, 'correct url')
-    var wrapped = arguments[1]
-    arguments[1] = function (res) {
-      t.equal(res.statusCode, 200, 'correct statusCode')
-      // simulates error during download
-      setTimeout(function () { res.emit('error', downloadError) }, 10)
-      wrapped(res)
-    }
+    t.equal('http://' + opts.uri.hostname + ':' + opts.uri.port + opts.uri.path, downloadUrl, 'correct url')
     return _request.apply(http, arguments)
   }
 
@@ -264,7 +252,7 @@ test('error during download should fail with no dangling temp file', function (t
     res.write('yep') // simulates hanging request
   }).listen(8889, function () {
     download(opts, function (err) {
-      t.equal(err.message, downloadError.message, 'correct error')
+      t.equal(err.message, 'ESOCKETTIMEDOUT', 'correct error')
       t.equal(fs.existsSync(tempFile), false, 'no dangling temp file')
       t.equal(fs.existsSync(cachedPrebuild), false, 'nothing cached')
       t.end()

--- a/test/download-test.js
+++ b/test/download-test.js
@@ -219,8 +219,6 @@ test('existing host but invalid url should fail', function (t) {
 test('error during download should fail with no dangling temp file', function (t) {
   t.plan(6)
 
-  var downloadError = new Error('something went wrong during download')
-
   var opts = getOpts()
   opts.pkg.binary = {
     host: 'http://localhost:8889',


### PR DESCRIPTION
I've taken a crack at solving https://github.com/mafintosh/prebuild/issues/35. In the comments you hinted at using [got](https://www.npmjs.com/package/got), but I used [request](https://www.npmjs.com/package/request) here, because afaict got doesn't actually read the npm proxy settings.

Couldn't get 1 test to work, where an error event is emitted directly into the response, so this is not perfect. Also, there's remaining work - to create tests with a proxy. Would appreciate any help with that!
