### PR TITLE
Fix regression in the strip implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "os-homedir": "^1.0.1",
     "pump": "^1.0.0",
     "rc": "^1.0.3",
+    "shell-quote": "^1.6.1",
     "simple-get": "^1.4.2",
     "tar-fs": "^1.7.0",
     "tar-stream": "^1.2.1",

--- a/strip.js
+++ b/strip.js
@@ -1,10 +1,12 @@
+var quote = require('shell-quote').quote
 var util = require('./util')
 
 function strip (file, cb) {
   // TODO no support on windows, noop
   var platform = util.platform()
   if (platform === 'win32') return process.nextTick(cb)
-  util.spawn('strip', stripArgs(platform, file), cb)
+  var argv = ['strip'].concat(stripArgs(platform, file))
+  util.spawn(quote(argv), cb)
 }
 
 function stripArgs (platform, file) {


### PR DESCRIPTION
The internal `spawn()` utility function's API recently changed, but the `strip()` implementation did not follow along. This fixes the regression.

Sadly this PR introduces a new dependency in order to do proper quoting -- though I'm not familiar enough with prebuild to say whether we can assume that quoting will never be needed, i.e. the `file` argument never contains spaces.

/cc @ralphtheninja