### PR TITLE
Build from source if used inside electron

### DIFF
--- a/rc.js
+++ b/rc.js
@@ -25,6 +25,12 @@ for (var j = 0; j < npmconfigs.length; ++j) {
   }
 }
 
+// Ensure that modules used inside electron are build from source
+if (process.env['npm_config_runtime'] === 'electron' &&
+    process.argv.indexOf('--build-from-source') === -1) {
+  process.argv.push('--build-from-source')
+}
+
 var rc = module.exports = require('rc')('prebuild', {
   target: process.version,
   arch: process.arch,

--- a/test/rc-test.js
+++ b/test/rc-test.js
@@ -100,6 +100,16 @@ test('npm_config_* are passed on from environment into rc', function (t) {
   })
 })
 
+test('modules are build from source when used inside electron', function (t) {
+  var env = {
+    npm_config_runtime: 'electron'
+  }
+  runRc(t, '', env, function (rc) {
+    t.equal(rc.compile, true, 'compile is set')
+    t.end()
+  })
+})
+
 function runRc (t, args, env, cb) {
   var cmd = 'node ' + path.resolve(__dirname, '..', 'rc.js') + ' ' + args
   env = xtend(process.env, env)


### PR DESCRIPTION
Since we don't support prebuilts for Electron we should build from source if the `--runtime=electron` flag is used by `npm`.
It is necessary to build native modules from source to ensure that they are build against the correct Electron headers: http://electron.atom.io/docs/tutorial/using-native-node-modules/

This is especially useful if the module is used inside a Atom package: https://github.com/atom/apm/pull/638