### PR TITLE
Remove --abi option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The following placeholders can be used:
 * `{patch}`: patch version taken from `version`
 * `{prerelease}`: prelease version taken from `version`
 * `{build}`: build version taken from `version`
-* `{abi}` or `{node_abi}`: ABI version of node/iojs taken from current `--target` or `process.version` if not specified, see `ABI` section below for more information
+* `{abi}` or `{node_abi}`: ABI version of node/iojs taken from current `--target` or `process.versions.node` if not specified, see `ABI` section below for more information
 * `{platform}`: platform taken from `--platform` or `process.platform` if not specified
 * `{arch}`: architecture taken from `--arch` or `process.arch` if not specified
 * `{libc}`: libc setting for alternative libc taken from `--libc` or LIBC env var or blank if not specified
@@ -143,7 +143,6 @@ prebuild [options]
   --preinstall  -i  script      (run this script before prebuilding)
   --compile     -c              (compile your project using node-gyp)
   --no-compile                  (skip compile fallback when downloading)
-  --abi                         (use provided abi rather than system abi)
   --libc                        (use provided libc rather than system default)
   --backend                     (specify build backend, default is 'node-gyp')
   --strip                       (strip debug information)

--- a/abi.js
+++ b/abi.js
@@ -1,6 +1,23 @@
+var ver = require('semver')
 var gypinstall = require('./gypinstall')
 var util = require('./util')
 var error = require('./error')
+
+function getAbiFromTarget (target) {
+  if (!target) return process.versions.modules
+  if (!ver.valid(target)) {
+    throw error.noAbi(target)
+  }
+  if (ver.eq(target, process.versions.node)) return process.versions.modules
+  if (ver.satisfies(target, '^7.0.0')) return '51'
+  if (ver.satisfies(target, '^6.0.0')) return '48'
+  if (ver.satisfies(target, '^5.0.0')) return '47'
+  if (ver.satisfies(target, '^4.0.0')) return '46'
+  if (ver.satisfies(target, '^0.12.0')) return '14'
+  if (ver.satisfies(target, '^0.10.0')) return '11'
+
+  throw error.noAbi(target)
+}
 
 function getAbi (opts, version, cb) {
   var log = opts.log
@@ -50,4 +67,5 @@ function getAbi (opts, version, cb) {
   }
 }
 
-module.exports = getAbi
+exports.getAbi = getAbi
+exports.getAbiFromTarget = getAbiFromTarget

--- a/abi.js
+++ b/abi.js
@@ -1,20 +1,16 @@
-var ver = require('semver')
 var gypinstall = require('./gypinstall')
 var util = require('./util')
 var error = require('./error')
 
 function getAbiFromTarget (target) {
   if (!target) return process.versions.modules
-  if (!ver.valid(target)) {
-    throw error.noAbi(target)
-  }
-  if (ver.eq(target, process.versions.node)) return process.versions.modules
-  if (ver.satisfies(target, '^7.0.0')) return '51'
-  if (ver.satisfies(target, '^6.0.0')) return '48'
-  if (ver.satisfies(target, '^5.0.0')) return '47'
-  if (ver.satisfies(target, '^4.0.0')) return '46'
-  if (ver.satisfies(target, '^0.12.0')) return '14'
-  if (ver.satisfies(target, '^0.10.0')) return '11'
+  if (target === process.versions.node) return process.versions.modules
+  if (/^7\.[0-9]+\.[0-9]+/.test(target)) return '51'
+  if (/^6\.[0-9]+\.[0-9]+/.test(target)) return '48'
+  if (/^5\.[0-9]+\.[0-9]+/.test(target)) return '47'
+  if (/^4\.[0-9]+\.[0-9]+/.test(target)) return '46'
+  if (/^0\.12\.[0-9]+/.test(target)) return '14'
+  if (/^0\.10\.[0-9]+/.test(target)) return '11'
 
   throw error.noAbi(target)
 }

--- a/abi.js
+++ b/abi.js
@@ -5,12 +5,12 @@ var error = require('./error')
 function getAbiFromTarget (target) {
   if (!target) return process.versions.modules
   if (target === process.versions.node) return process.versions.modules
-  if (/^7\.[0-9]+\.[0-9]+/.test(target)) return '51'
-  if (/^6\.[0-9]+\.[0-9]+/.test(target)) return '48'
-  if (/^5\.[0-9]+\.[0-9]+/.test(target)) return '47'
-  if (/^4\.[0-9]+\.[0-9]+/.test(target)) return '46'
-  if (/^0\.12\.[0-9]+/.test(target)) return '14'
-  if (/^0\.10\.[0-9]+/.test(target)) return '11'
+  if (/^7\./.test(target)) return '51'
+  if (/^6\./.test(target)) return '48'
+  if (/^5\./.test(target)) return '47'
+  if (/^4\./.test(target)) return '46'
+  if (/^0\.12\./.test(target)) return '14'
+  if (/^0\.10\./.test(target)) return '11'
 
   throw error.noAbi(target)
 }

--- a/bin.js
+++ b/bin.js
@@ -6,6 +6,7 @@ var fs = require('fs')
 var async = require('async')
 var extend = require('xtend')
 
+var getAbiFromTarget = require('./abi').getAbiFromTarget
 var rc = require('./rc')
 var download = require('./download')
 var prebuild = require('./prebuild')
@@ -59,7 +60,12 @@ if (rc.install) {
 }
 
 var buildLog = log.info.bind(log, 'build')
-var opts = extend(rc, {pkg: pkg, log: log, buildLog: buildLog})
+var opts = extend(rc, {
+  abi: getAbiFromTarget(rc.target),
+  pkg: pkg,
+  log: log,
+  buildLog: buildLog
+})
 
 if (opts.compile) {
   build(opts, rc.target, onbuilderror)

--- a/help.txt
+++ b/help.txt
@@ -11,7 +11,6 @@ prebuild [options]
   --preinstall  -i  script      (run this script before prebuilding)
   --compile     -c              (compile your project using node-gyp)
   --no-compile                  (skip compile fallback when downloading)
-  --abi                         (use provided abi rather than system abi)
   --libc                        (use provided libc rather than system default)
   --backend                     (specify build backend, default is 'node-gyp')
   --strip                       (strip debug information)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "a-native-module": "^1.0.0",
     "nsp": "^2.2.0",
     "rimraf": "^2.4.2",
-    "semver": "^5.3.0",
     "standard": "^8.6.0",
     "tape": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "a-native-module": "^1.0.0",
     "nsp": "^2.2.0",
     "rimraf": "^2.4.2",
+    "semver": "^5.3.0",
     "standard": "^8.6.0",
     "tape": "^4.0.1"
   },

--- a/prebuild.js
+++ b/prebuild.js
@@ -1,6 +1,6 @@
 var fs = require('fs')
 var async = require('async')
-var getAbi = require('./abi')
+var getAbi = require('./abi').getAbi
 var getTarPath = require('./util').getTarPath
 var build = require('./build')
 var strip = require('./strip')

--- a/rc.js
+++ b/rc.js
@@ -16,7 +16,7 @@ if (process.env.npm_config_argv) {
   } catch (e) { }
 }
 
-var npmconfigs = ['proxy', 'https-proxy', 'local-address', 'target', 'abi']
+var npmconfigs = ['proxy', 'https-proxy', 'local-address', 'target']
 for (var j = 0; j < npmconfigs.length; ++j) {
   var envname = 'npm_config_' + npmconfigs[j].replace('-', '_')
   if (process.env[envname]) {
@@ -32,11 +32,10 @@ if (process.env['npm_config_runtime'] === 'electron' &&
 }
 
 var rc = module.exports = require('rc')('prebuild', {
-  target: process.version,
+  target: process.versions.node,
   arch: process.arch,
   libc: process.env.LIBC,
   platform: process.platform,
-  abi: process.versions.modules,
   all: false,
   force: false,
   debug: false,

--- a/test/abi-test.js
+++ b/test/abi-test.js
@@ -1,6 +1,6 @@
 var test = require('tape')
 var util = require('../util')
-var getAbi = require('../abi')
+var abi = require('../abi')
 var error = require('../error')
 
 test('src/node_version.h takes precedence over src/node.h', function (t) {
@@ -17,7 +17,7 @@ test('src/node_version.h takes precedence over src/node.h', function (t) {
       process.nextTick(cb.bind(null, null, '#define NODE_MODULE_VERSION 314'))
     }
   }
-  getAbi({}, v, function (err, abi) {
+  abi.getAbi({}, v, function (err, abi) {
     t.error(err, 'getAbi should not fail')
     t.equal(abi, '666', 'abi version taken from src/node_version.h')
     util.readGypFile = _readGypFile
@@ -36,7 +36,7 @@ test('abi taken from src/node.h if no define in src/node_version.h', function (t
       process.nextTick(cb.bind(null, null, '#define NODE_MODULE_VERSION 314'))
     }
   }
-  getAbi({}, v, function (err, abi) {
+  abi.getAbi({}, v, function (err, abi) {
     t.error(err, 'getAbi should not fail')
     t.equal(abi, '314', 'abi version taken from src/node.h')
     util.readGypFile = _readGypFile
@@ -50,7 +50,7 @@ test('getAbi calls back with error if no abi could be found', function (t) {
   util.readGypFile = function (opts, cb) {
     process.nextTick(cb.bind(null, null, 'no proper define here!'))
   }
-  getAbi({}, v, function (err, abi) {
+  abi.getAbi({}, v, function (err, abi) {
     t.same(err, error.noAbi(v), 'correct error')
     util.readGypFile = _readGypFile
     t.end()
@@ -76,7 +76,7 @@ test('missing src/node_version.h will run node-gyp-install and retry', function 
       process.nextTick(cb)
     }
   }
-  getAbi(opts, v, function (err, abi) {
+  abi.getAbi(opts, v, function (err, abi) {
     t.error(err, 'getAbi should not fail')
     t.equal(readCount, 3, 'read three times')
     t.equal(abi, '555', 'abi version after retry')

--- a/test/abi-test.js
+++ b/test/abi-test.js
@@ -3,6 +3,26 @@ var util = require('../util')
 var abi = require('../abi')
 var error = require('../error')
 
+test('getAbiFromTarget calculates correct Node ABI', function (t) {
+  t.equal(abi.getAbiFromTarget(undefined), process.versions.modules)
+  t.equal(abi.getAbiFromTarget(null), process.versions.modules)
+  t.throws(function () { abi.getAbiFromTarget('a.b.c') })
+  t.throws(function () { abi.getAbiFromTarget('1.0.0') })
+  t.equal(abi.getAbiFromTarget('7.2.0'), '51')
+  t.equal(abi.getAbiFromTarget('7.0.0'), '51')
+  t.equal(abi.getAbiFromTarget('6.9.9'), '48')
+  t.equal(abi.getAbiFromTarget('6.0.0'), '48')
+  t.equal(abi.getAbiFromTarget('5.9.9'), '47')
+  t.equal(abi.getAbiFromTarget('5.0.0'), '47')
+  t.equal(abi.getAbiFromTarget('4.9.9'), '46')
+  t.equal(abi.getAbiFromTarget('4.0.0'), '46')
+  t.equal(abi.getAbiFromTarget('0.12.17'), '14')
+  t.equal(abi.getAbiFromTarget('0.12.0'), '14')
+  t.equal(abi.getAbiFromTarget('0.10.48'), '11')
+  t.equal(abi.getAbiFromTarget('0.10.0'), '11')
+  t.end()
+})
+
 test('src/node_version.h takes precedence over src/node.h', function (t) {
   var readCount = 0
   var v = 'vX.Y.Z'

--- a/test/download-test.js
+++ b/test/download-test.js
@@ -5,7 +5,6 @@ var path = require('path')
 var http = require('http')
 var https = require('https')
 var download = require('../download')
-var rc = require('../rc')
 var util = require('../util')
 var error = require('../error')
 
@@ -276,7 +275,7 @@ test('error during download should fail with no dangling temp file', function (t
 
 test('should fail if abi is system abi with invalid binary', function (t) {
   var opts = getOpts()
-  opts.abi = rc.abi
+  opts.abi = process.versions.modules
   opts.pkg.binary = {host: 'http://localhost:8890'}
 
   var server = http.createServer(function (req, res) {
@@ -303,7 +302,6 @@ function getOpts () {
     platform: process.platform,
     arch: process.arch,
     path: __dirname,
-    target: process.version,
     log: {http: function (type, message) {}, info: function (type, message) {}}
   }
 }

--- a/test/rc-test.js
+++ b/test/rc-test.js
@@ -90,12 +90,14 @@ test('npm_config_* are passed on from environment into rc', function (t) {
   var env = {
     npm_config_proxy: 'PROXY',
     npm_config_https_proxy: 'HTTPS_PROXY',
-    npm_config_local_address: 'LOCAL_ADDRESS'
+    npm_config_local_address: 'LOCAL_ADDRESS',
+    npm_config_target: '7.0.0'
   }
   runRc(t, '', env, function (rc) {
     t.equal(rc.proxy, 'PROXY', 'proxy is set')
     t.equal(rc['https-proxy'], 'HTTPS_PROXY', 'https-proxy is set')
     t.equal(rc['local-address'], 'LOCAL_ADDRESS', 'local-address is set')
+    t.equal(rc.target, '7.0.0', 'target is set')
     t.end()
   })
 })


### PR DESCRIPTION
This removes the `--abi` option since it does the same thing as `--target`. The ABI will now be determined based on the target.

This will allow for `npm install --target=7.0.0` and `npm rebuild --target=7.0.0` without needing to specify a ABI. If i recall correctly `--target` is a "official" `npm` option in contrast to `--abi`.

In the process I also changed the usage of `process.version` to `process.versions.node` since `process.version` would return `v7.0.0` instead of `7.0.0`.

This behavior is also prerequisite for #61 to determine the right version when installing modules with `npm install --runtime=electron --target=1.4.10 --dist-url=https://atom.io/download/electron`.