### PR TITLE
Don't use npm log level

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -24,8 +24,6 @@ if (rc.path) process.chdir(rc.path)
 log.heading = 'prebuild'
 if (rc.verbose) {
   log.level = 'verbose'
-} else if (process.env.npm_config_loglevel) {
-  log.level = process.env.npm_config_loglevel
 }
 
 if (!fs.existsSync('package.json')) {


### PR DESCRIPTION
The default log level of `npm` is `warn`.
Hence no log messages of `prebuild` are shown when it is used inside a `npm`-script.