### PR TITLE
Don't default to compile if installed via yarn

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -3,6 +3,7 @@
 var path = require('path')
 var log = require('npmlog')
 var fs = require('fs')
+var home = require('os-homedir')
 var async = require('async')
 var extend = require('xtend')
 
@@ -12,6 +13,7 @@ var download = require('./download')
 var prebuild = require('./prebuild')
 var build = require('./build')
 var upload = require('./upload')
+var util = require('./util')
 
 var prebuildVersion = require('./package.json').version
 if (rc.version) {
@@ -46,8 +48,13 @@ log.info('begin', 'Prebuild version', prebuildVersion)
 delete process.env.NVM_IOJS_ORG_MIRROR
 delete process.env.NVM_NODEJS_ORG_MIRROR
 
+var execPath = process.env.npm_execpath || process.env.NPM_CLI_JS
+
 if (rc.install) {
-  if (!(typeof pkg._from === 'string')) {
+  if (util.isYarnPath(execPath) && /node_modules/.test(home())) {
+    // From yarn repository
+    rc.download = rc.install
+  } else if (!(typeof pkg._from === 'string')) {
     // From Git directly
     rc.compile = true
   } else if (pkg._from.length > 4 && pkg._from.substr(0, 4) === 'git+') {

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -233,3 +233,12 @@ test('releaseFolder(): depends on package.json and --debug', function (t) {
   }), 'foo/bar', 'using binary property from package.json')
   t.end()
 })
+
+test('isYarnPath(): returns correct value', function (t) {
+  var yarn = util.isYarnPath
+  t.equal(yarn(null), false)
+  t.equal(yarn(undefined), false)
+  t.equal(yarn('/usr/local/lib/node_modules/npm/bin/npm-cli.js'), false)
+  t.equal(yarn('/usr/local/opt/yarn/libexec/lib/node_modules/yarn/bin/yarn.js'), true)
+  t.end()
+})

--- a/util.js
+++ b/util.js
@@ -111,6 +111,10 @@ function releaseFolder (opts, version) {
   }
 }
 
+function isYarnPath (execPath) {
+  return execPath != null && path.basename(execPath).startsWith('yarn')
+}
+
 exports.getDownloadUrl = getDownloadUrl
 exports.urlTemplate = urlTemplate
 exports.cachedPrebuild = cachedPrebuild
@@ -123,3 +127,4 @@ exports.spawn = spawn
 exports.exec = exec
 exports.platform = platform
 exports.releaseFolder = releaseFolder
+exports.isYarnPath = isYarnPath

--- a/util.js
+++ b/util.js
@@ -112,7 +112,7 @@ function releaseFolder (opts, version) {
 }
 
 function isYarnPath (execPath) {
-  return execPath != null && path.basename(execPath).startsWith('yarn')
+  return execPath ? /^yarn/.test(path.basename(execPath)) : false
 }
 
 exports.getDownloadUrl = getDownloadUrl


### PR DESCRIPTION
Fixes #132 

This is the way [`electron-builder`](https://github.com/electron-userland/electron-builder) determines if it's installed via Yarn.