### PR TITLE
Get target architecture from npm config environment variables

### DIFF
--- a/rc.js
+++ b/rc.js
@@ -30,7 +30,7 @@ module.exports = function (pkg) {
   var rc = require('rc')('prebuild', {
     target: pkgConf.target || process.versions.node,
     runtime: pkgConf.runtime || 'node',
-    arch: pkgConf.arch || process.arch,
+    arch: pkgConf.arch || process.env.npm_config_arch || process.arch,
     libc: process.env.LIBC,
     platform: process.platform,
     all: false,


### PR DESCRIPTION
This allow to set the architecture for cross-compile environment by using
`npm install --arch=<arch>`.

This should fix issue #69.