### PR TITLE
support abi number as target parameter too

### DIFF
--- a/prebuild.js
+++ b/prebuild.js
@@ -1,6 +1,5 @@
 var fs = require('fs')
 var async = require('async')
-var getAbi = require('node-abi').getAbi
 var getTarPath = require('./util').getTarPath
 var build = require('./build')
 var strip = require('./strip')
@@ -15,7 +14,9 @@ function prebuild (opts, target, runtime, callback) {
   var buildLogMessage = 'Preparing to prebuild ' + pkg.name + '@' + pkg.version + ' for ' + runtime + ' ' + target + ' on ' + opts.platform + '-' + opts.arch + ' using ' + opts.backend
   if (opts.libc && opts.libc.length > 0) buildLogMessage += 'using libc ' + opts.libc
   buildLog(buildLogMessage)
-  var abi = getAbi(target, runtime)
+  var abi = String(target) === String(Number(target))
+    ? target
+    : getAbi(target, runtime)
   var tarPath = getTarPath(opts, abi)
   fs.stat(tarPath, function (err, st) {
     if (!err && !opts.force) {


### PR DESCRIPTION
This is useful so when you pass --runtime=electron --target=50 to prebuild it still works. I need this functionality for prebuild-ci.

In the future this probably will be supported via https://github.com/lgeiger/node-abi/pull/5.