### PR TITLE
Bump node-abi@2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "github-from-package": "0.0.0",
     "minimist": "^1.1.2",
     "mkdirp": "^0.5.1",
-    "node-abi": "^1.3.0",
+    "node-abi": "^2.0.0",
     "node-gyp": "^3.0.3",
     "node-ninja": "^1.0.1",
     "noop-logger": "^0.1.0",

--- a/rc.js
+++ b/rc.js
@@ -1,5 +1,5 @@
 var minimist = require('minimist')
-var targets = require('node-abi').allTargets
+var targets = require('node-abi').supportedTargets
 
 var rc = require('rc')('prebuild', {
   target: process.versions.node,

--- a/test/rc-test.js
+++ b/test/rc-test.js
@@ -2,7 +2,7 @@ var test = require('tape')
 var path = require('path')
 var exec = require('child_process').exec
 var xtend = require('xtend')
-var targets = require('node-abi').allTargets
+var targets = require('node-abi').supportedTargets
 
 test('custom config and aliases', function (t) {
   var args = [


### PR DESCRIPTION
This adds Electron 1.5 and 1.6 to supported Targets