### PR TITLE
Allow strip program to be overridden

### DIFF
--- a/strip.js
+++ b/strip.js
@@ -4,7 +4,7 @@ function strip (file, cb) {
   // TODO no support on windows, noop
   var platform = util.platform()
   if (platform === 'win32') return process.nextTick(cb)
-  util.spawn('strip', stripArgs(platform, file), cb)
+  util.spawn(process.env.STRIP || 'strip', stripArgs(platform, file), cb)
 }
 
 function stripArgs (platform, file) {


### PR DESCRIPTION
Through the `STRIP` environment variable. This is sometimes necessary when
cross-compiling, and is consistent with how gyp allows e.g. `CXX` to be set
to override the C++ compiler used. The name `STRIP` was chosen as autotools
also uses it to override its auto-detection.

Note: I wasn't sure if this should be integrated in the `rc` module or done locally,
so I went for the latter. Please let me know what you'd prefer.